### PR TITLE
(qa-3199) qaelk add yard/rubocop travis jobs for doctor teeth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+git:
+    depth: 3
+cache: bundler
+bundler_args: --without development
+script:
+    - "bundle exec rake $CHECK"
+notifications:
+    email: false
+rvm:
+    - 2.4.0
+env:
+    - "CHECK=docs:yard"
+    # FIXME: turn this back on after more testing and refactor away cop issues
+    #- "CHECK=test:rubocop"

--- a/Gemfile
+++ b/Gemfile
@@ -15,19 +15,18 @@ def location_for(place, fake_version = nil)
   end
 end
 
-# unit tests: --without system_tests development
+# lint/unit tests: --without system_tests development
 gem 'rake'
 gem 'rspec'
+gem 'rubocop', '~> 0.49.1', require: false # used in tests. pinned
+# Documentation dependencies
+gem 'yard', '~> 0'
 
 group :system_tests do
 end
 
 group :development do
   gem 'bundler' # bundler rake tasks
-  gem 'rubocop', '~> 0.49.1', require: false # used in tests. pinned
-  # Documentation dependencies
-  gem 'markdown', '~> 0'
-  gem 'yard', '~> 0'
 end
 
 local_gemfile = "#{__FILE__}.local"


### PR DESCRIPTION
applicable commits here:

**(QA-3199) move rubocop and yard out of development Gemfile group**
* development to be used for local development tasks 
* main gemfile to be used for automated tests of different types   
* travis can run --without development 

**(QA-3199) rubocop travis jobs for doctor teeth**
* no need to pull default 50 git commits  
  * pull 3 
* cache the bundle so other jobs can use it 
* run yard and rubocop jobs in parallel by using `env:`

