### PR TITLE
(QA-3330) prep docker centos7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM centos:7
+MAINTAINER Eric Thompson <erict@puppet.com>
+
+RUN yum -y update && yum -y install git ruby ruby-devel make gcc gcc-c++ zlib-devel && yum clean all
+# skip installing gem documentation
+RUN echo 'gem: --no-rdoc --no-ri' >> "$HOME/.gemrc"
+RUN gem install bundler
+
+RUN git clone https://github.com/puppetlabs/doctor_teeth.git
+WORKDIR doctor_teeth
+
+RUN bundle install

--- a/doctor_teeth.gemspec
+++ b/doctor_teeth.gemspec
@@ -16,8 +16,10 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
 
   # Run time dependencies
-  s.add_runtime_dependency 'nokogiri', '~> 1.8.0'
-  s.add_runtime_dependency 'sinatra',  '~> 2.0.0'
+  #   pin nokogiri so it can run on centos7 native ruby 2.0.0
+  s.add_runtime_dependency 'nokogiri', '~> 1.6.0'
+  #   pin sinatra so it can run on centos7 native ruby 2.0.0
+  s.add_runtime_dependency 'sinatra',  '~> 1.4.0'
   s.add_runtime_dependency 'thin',     '~> 1.7.0'
   s.add_runtime_dependency 'github-markdown'
 end


### PR DESCRIPTION
* create a barebones docker file
  * use a git clone and bundle install so we skip all this during test runs
  * future dockerfiles should COPY . . to move local changes (and travis changes) to the container and then bundle update
* update Gemfile for centos7's ruby 2.0.0