### PR TITLE
(maint) update nokogiri dep cve-2017-9050

### DIFF
--- a/doctor_teeth.gemspec
+++ b/doctor_teeth.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   #   pin nokogiri so it can run on centos7 native ruby 2.0.0
-  s.add_runtime_dependency "nokogiri", "~> 1.6.0"
+  s.add_runtime_dependency "nokogiri", "~> 1.8.1"
   #   pin sinatra so it can run on centos7 native ruby 2.0.0
   s.add_runtime_dependency "sinatra",  "~> 1.4.0"
   s.add_runtime_dependency "thin",     "~> 1.7.0"


### PR DESCRIPTION
update the nokogiri dep version for CVE 2017-9050 vulnerability